### PR TITLE
Add regex validation support

### DIFF
--- a/src/main/resources/ApacheCXFJaxRS/dto.mustache
+++ b/src/main/resources/ApacheCXFJaxRS/dto.mustache
@@ -9,6 +9,7 @@ import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 {{#models}}
 
@@ -30,9 +31,9 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
   public enum {{datatypeWithEnum}} {
     {{#allowableValues}}{{#values}} {{.}}, {{/values}}{{/allowableValues}}
   };
-  {{#required}}@NotNull{{/required}}
+  {{#required}}@NotNull {{/required}}{{#pattern}}@Pattern(regexp="{{{pattern}}}"){{/pattern}}
   private {{{datatypeWithEnum}}} {{name}} = {{{defaultValue}}};{{/isEnum}}{{^isEnum}}
-  {{#required}}@NotNull{{/required}}
+  {{#required}}@NotNull {{/required}}{{#pattern}}@Pattern(regexp="{{{pattern}}}"){{/pattern}}
   private {{{datatype}}} {{name}} = {{{defaultValue}}};{{/isEnum}}{{/vars}}
 
   {{#vars}}


### PR DESCRIPTION
Support regex validation for the DTOs by adding "pattern" to the swagger.

ex:
```
ssn:
  type: string
  pattern: '^\d{3}-\d{2}-\d{4}$'
```

ref: 

1. https://swagger.io/docs/specification/data-models/data-types/
2. https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/JavaSpring/beanValidationCore.mustache