### PR TITLE
Enable @JsonIgnoreProperties Annotation for Claim Management DTO

### DIFF
--- a/src/main/java/org/wso2/maven/plugins/CxfCodeGen.java
+++ b/src/main/java/org/wso2/maven/plugins/CxfCodeGen.java
@@ -92,12 +92,12 @@ public class CxfCodeGen extends JavaCXFServerCodegen {
 
         //generate the Impl in main directory
         if (templateName.endsWith("Impl.mustache")) {
-            String split[] = result.split(File.separator);
+            String split[] = result.split("[/\\\\]");
             result = getMainDirectory() + File.separator + "impl" + File.separator + split[split.length -1];
         }
 
         if (templateName.endsWith("Factory.mustache")) {
-            String split[] = result.split(File.separator);
+            String split[] = result.split("[/\\\\]");
             result = getGenDirectory() + File.separator + "factories" + File.separator + split[split.length -1];
         }
 

--- a/src/main/resources/ApacheCXFJaxRS/dto.mustache
+++ b/src/main/resources/ApacheCXFJaxRS/dto.mustache
@@ -23,6 +23,7 @@ import javax.validation.constraints.Pattern;
     })
 {{/discriminator}}
 @ApiModel(description = "{{{description}}}")
+{{#vendorExtensions.x-wso2-json-ignore-unknown}}@JsonIgnoreProperties(ignoreUnknown = true){{/vendorExtensions.x-wso2-json-ignore-unknown}}
 public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}} {
 {{#vars}}{{#isEnum}}
     public enum {{datatypeWithEnum}} {


### PR DESCRIPTION
## Purpose
Add support for **@JsonIgnoreProperties(ignoreUnknown = true)** annotation to be used by claim management API DTO.

Additionally, fixed a bug which prevents the plugin from running in Windows environment due to backslash in file path.

## Approach
Added {{#vendorExtensions.x-wso2-json-ignore-unknown}}

## Related PRs
https://github.com/wso2/identity-api-server/pull/449